### PR TITLE
Feature/lazy load images

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -7,7 +7,8 @@ const httpClient = axios.create({
 })
 
 const getNewsArticles = () => {
-  const url = "https://my.api.mockaroo.com/fed-exercise-data.json"
+  // const url = "https://my.api.mockaroo.com/fed-exercise-data.json"
+  const url = "/articles.json"
   const params = { key: "cf334d90" }
   return httpClient.get(url, { params })
 }

--- a/src/components/ArticleCard.vue
+++ b/src/components/ArticleCard.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="card" :class="layoutClass">
-    <figure class="card__image">
-      <img :src="image" :alt="altText" />
+    <figure v-lazyload class="card__image">
+      <img :data-src="image" :alt="altText" />
     </figure>
     <div class="card__content">
       <div class="card__header">

--- a/src/components/ArticleCard.vue
+++ b/src/components/ArticleCard.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="card" :class="layoutClass">
-    <div class="card__image">
+    <figure class="card__image">
       <img :src="image" :alt="altText" />
-    </div>
+    </figure>
     <div class="card__content">
       <div class="card__header">
         <slot name="header" />

--- a/src/directives/lazy-load-image.js
+++ b/src/directives/lazy-load-image.js
@@ -1,0 +1,41 @@
+export default {
+  inserted: el => {
+    const loadImage = () => {
+      const imageElement = Array.from(el.children).find(
+        el => el.nodeName === "IMG"
+      )
+
+      if (imageElement) {
+        imageElement.addEventListener("load", () => {
+          setTimeout(() => el.classList.add("loaded"), 100)
+        })
+        imageElement.addEventListener("error", () => console.log("error"))
+        imageElement.src = imageElement.dataset.src
+      }
+    }
+
+    const handleIntersect = (entries, observer) => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) {
+          loadImage()
+          observer.unobserve(el)
+        }
+      })
+    }
+
+    const createObserver = () => {
+      const options = {
+        root: null,
+        threshold: "0"
+      }
+      const observer = new IntersectionObserver(handleIntersect, options)
+      observer.observe(el)
+    }
+
+    if (window["IntersectionObserver"]) {
+      createObserver()
+    } else {
+      loadImage()
+    }
+  }
+}

--- a/src/main.js
+++ b/src/main.js
@@ -2,8 +2,11 @@ import Vue from "vue"
 import App from "./App.vue"
 import router from "./router"
 import store from "./store"
+import LazyLoadImageDirective from "@/directives/lazy-load-image"
 
 Vue.config.productionTip = false
+
+Vue.directive("lazyload", LazyLoadImageDirective)
 
 new Vue({
   router,


### PR DESCRIPTION
Add lazy load directive (`v-lazyload`) to be used on the `ArticleCard` component so that images only load when they enter into the viewport. 

See [this CSS-tricks article](https://css-tricks.com/lazy-loading-images-with-vue-js-directives-and-intersection-observer/) for details